### PR TITLE
Adds Service marker - @Service

### DIFF
--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
@@ -18,7 +18,7 @@ final class ModuleReader {
 
   private boolean coreWarning;
 
-  public ModuleReader(Map<String, Set<String>> services) {
+  ModuleReader(Map<String, Set<String>> services) {
     services.forEach(this::add);
   }
 
@@ -26,10 +26,8 @@ final class ModuleReader {
     missingServicesMap.put(k.replace("$", "."), v);
   }
 
-  public void read(BufferedReader reader, ModuleElement element) throws IOException {
-
+  void read(BufferedReader reader, ModuleElement element) throws IOException {
     var module = new ModuleInfoReader(element, reader);
-
     for (var require : module.requires()) {
       var dep = require.getDependency();
       if (!require.isStatic() && dep.getQualifiedName().contentEquals("io.avaje.spi")) {
@@ -49,25 +47,22 @@ final class ModuleReader {
             p -> {
               var impls = p.implementations();
               var missing = missingServicesMap.get(p.service());
-
               if (missing.size() != impls.size()) {
-
                 return;
               }
-
               impls.forEach(missing::remove);
             });
   }
 
-  public boolean staticWarning() {
+  boolean staticWarning() {
     return staticWarning;
   }
 
-  public boolean coreWarning() {
+  boolean coreWarning() {
     return coreWarning;
   }
 
-  public Map<String, Set<String>> missing() {
+  Map<String, Set<String>> missing() {
     return missingServicesMap;
   }
 }

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
@@ -1,7 +1,5 @@
 package io.avaje.spi.internal;
 
-import static java.util.stream.Collectors.toSet;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.HashMap;
@@ -11,10 +9,9 @@ import java.util.Set;
 import javax.lang.model.element.ModuleElement;
 
 import io.avaje.prism.GenerateModuleInfoReader;
-import io.avaje.spi.internal.ModuleInfoReader.Provides;
 
 @GenerateModuleInfoReader
-public final class ModuleReader {
+final class ModuleReader {
   private final Map<String, Set<String>> missingServicesMap = new HashMap<>();
 
   private boolean staticWarning;
@@ -48,7 +45,18 @@ public final class ModuleReader {
 
     module.provides().stream()
         .filter(p -> missingServicesMap.containsKey(p.service()))
-        .forEach(p -> p.implementations().forEach(missingServicesMap.get(p.service())::remove));
+        .forEach(
+            p -> {
+              var impls = p.implementations();
+              var missing = missingServicesMap.get(p.service());
+
+              if (missing.size() != impls.size()) {
+
+                return;
+              }
+
+              impls.forEach(missing::remove);
+            });
   }
 
   public boolean staticWarning() {

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServicePrism.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServicePrism.java
@@ -1,0 +1,123 @@
+package io.avaje.spi.internal;
+
+import java.util.Optional;
+
+import javax.annotation.processing.Generated;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+/** A Prism representing a {@link io.avaje.spi.Service @Service} annotation. */
+@Generated("avaje-prism-generator")
+final class ServicePrism {
+  public static final String PRISM_TYPE = "io.avaje.spi.Service";
+
+  /**
+   * Returns true if the mirror is an instance of {@link io.avaje.spi.Service @Service} is present
+   * on the element, else false.
+   *
+   * @param mirror mirror.
+   * @return true if prism is present.
+   */
+  static boolean isInstance(AnnotationMirror mirror) {
+    return getInstance(mirror) != null;
+  }
+
+  /**
+   * Returns true if {@link io.avaje.spi.Service @Service} is present on the element, else false.
+   *
+   * @param element element.
+   * @return true if annotation is present on the element.
+   */
+  static boolean isPresent(Element element) {
+    return getInstanceOn(element) != null;
+  }
+
+  /**
+   * Return a prism representing the {@link io.avaje.spi.Service @Service} annotation present on the
+   * given element. similar to {@code element.getAnnotation(Service.class)} except that an instance
+   * of this class rather than an instance of {@link io.avaje.spi.Service @Service} is returned.
+   *
+   * @param element element.
+   * @return prism on element or null if no annotation is found.
+   */
+  static ServicePrism getInstanceOn(Element element) {
+    final var mirror = getMirror(element);
+    if (mirror == null) return null;
+    return getInstance(mirror);
+  }
+
+  /**
+   * Return a Optional representing a nullable {@link io.avaje.spi.Service @Service} annotation on
+   * the given element. similar to {@code element.getAnnotation(io.avaje.spi.Service.class)} except
+   * that an Optional of this class rather than an instance of {@link io.avaje.spi.Service} is
+   * returned.
+   *
+   * @param element element.
+   * @return prism optional for element.
+   */
+  static Optional<ServicePrism> getOptionalOn(Element element) {
+    final var mirror = getMirror(element);
+    if (mirror == null) return Optional.empty();
+    return getOptional(mirror);
+  }
+
+  /**
+   * Return a prism of the {@link io.avaje.spi.Service @Service} annotation from an annotation
+   * mirror.
+   *
+   * @param mirror mirror.
+   * @return prism for mirror or null if mirror is an incorrect type.
+   */
+  static ServicePrism getInstance(AnnotationMirror mirror) {
+    if (mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return null;
+
+    return new ServicePrism(mirror);
+  }
+
+  /**
+   * Return an Optional representing a nullable {@link ServicePrism @ServicePrism} from an
+   * annotation mirror. similar to {@code e.getAnnotation(io.avaje.spi.Service.class)} except that
+   * an Optional of this class rather than an instance of {@link io.avaje.spi.Service @Service} is
+   * returned.
+   *
+   * @param mirror mirror.
+   * @return prism optional for mirror.
+   */
+  static Optional<ServicePrism> getOptional(AnnotationMirror mirror) {
+    if (mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString()))
+      return Optional.empty();
+
+    return Optional.of(new ServicePrism(mirror));
+  }
+
+  private ServicePrism(AnnotationMirror mirror) {
+    this.mirror = mirror;
+    this.isValid = valid;
+  }
+
+  /**
+   * Determine whether the underlying AnnotationMirror has no errors. True if the underlying
+   * AnnotationMirror has no errors. When true is returned, none of the methods will return null.
+   * When false is returned, a least one member will either return null, or another prism that is
+   * not valid.
+   */
+  final boolean isValid;
+
+  /**
+   * The underlying AnnotationMirror of the annotation represented by this Prism. Primarily intended
+   * to support using Messager.
+   */
+  final AnnotationMirror mirror;
+
+  private final boolean valid = true;
+
+  private static AnnotationMirror getMirror(Element target) {
+    for (final var m : target.getAnnotationMirrors()) {
+      final CharSequence mfqn =
+          ((TypeElement) m.getAnnotationType().asElement()).getQualifiedName();
+      if (PRISM_TYPE.contentEquals(mfqn)) return m;
+    }
+    return null;
+  }
+}

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
@@ -80,7 +80,6 @@ public class ServiceProcessor extends AbstractProcessor {
 
     // discover services from the current compilation sources
     for (final var type : ElementFilter.typesIn(annotated)) {
-
       validate(type);
 
       final List<TypeElement> contracts = getServiceInterfaces(type);
@@ -149,7 +148,6 @@ public class ServiceProcessor extends AbstractProcessor {
 
     // Write the service files
     for (final Map.Entry<String, Set<String>> e : services.entrySet()) {
-
       final String contract = e.getKey();
       logNote("Writing META-INF/services/%s", contract);
       try (final var file =
@@ -220,12 +218,10 @@ public class ServiceProcessor extends AbstractProcessor {
       return true;
     }
     final List<TypeMirror> supers = new ArrayList<>();
-
     supers.add(type.getSuperclass());
     supers.addAll(type.getInterfaces());
-
-    for (var s : supers) {
-      if (checkSPI(s, typeElementList)) {
+    for (var aSuper : supers) {
+      if (checkSPI(aSuper, typeElementList)) {
         return true;
       }
     }
@@ -316,7 +312,6 @@ public class ServiceProcessor extends AbstractProcessor {
   }
 
   private static boolean buildPluginAvailable() {
-
     return resource("target/avaje-plugin-exists.txt", "/target/classes")
         || resource("build/avaje-plugin-exists.txt", "/build/classes/java/main");
   }

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProviderPrism.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProviderPrism.java
@@ -1,16 +1,17 @@
 package io.avaje.spi.internal;
 
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Map;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.AnnotationValue;
-import javax.lang.model.type.TypeMirror;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 
 /** A Prism representing a {@link io.avaje.spi.ServiceProvider @ServiceProvider} annotation. */

--- a/avaje-spi-service/src/main/java/io/avaje/spi/Service.java
+++ b/avaje-spi-service/src/main/java/io/avaje/spi/Service.java
@@ -1,0 +1,34 @@
+package io.avaje.spi;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class/interface as service type (not an implementation).
+ *
+ * <p>Use when the type is meant to be the default inferred type.
+ *
+ * <pre>{@code
+ * @Service
+ * sealed class A permits B {
+ *   ...
+ * }
+ *
+ * non-sealed class B extends A {
+ *   ...
+ * }
+ *
+ * //the default inferred SPI is A instead of B
+ * &#64;ServiceProvider
+ * class C extends B {
+ *   ...
+ * }
+ *
+ * }</pre>
+ */
+@Target(TYPE)
+@Retention(CLASS)
+public @interface Service {}

--- a/blackbox-test-spi/src/main/java/io/avaje/spi/test/AbstractSPIExtension.java
+++ b/blackbox-test-spi/src/main/java/io/avaje/spi/test/AbstractSPIExtension.java
@@ -1,0 +1,5 @@
+package io.avaje.spi.test;
+
+public abstract class AbstractSPIExtension implements SPIInterface {
+  public abstract void doSomething();
+}

--- a/blackbox-test-spi/src/main/java/io/avaje/spi/test/CommonClass3.java
+++ b/blackbox-test-spi/src/main/java/io/avaje/spi/test/CommonClass3.java
@@ -1,0 +1,12 @@
+package io.avaje.spi.test;
+
+import io.avaje.spi.ServiceProvider;
+
+@ServiceProvider
+public class CommonClass3 extends AbstractSPIExtension {
+
+  @Override
+  public void doSomething() {
+    System.out.println("some string idk");
+  }
+}

--- a/blackbox-test-spi/src/main/java/io/avaje/spi/test/SPIInterface.java
+++ b/blackbox-test-spi/src/main/java/io/avaje/spi/test/SPIInterface.java
@@ -1,5 +1,8 @@
 package io.avaje.spi.test;
 
+import io.avaje.spi.Service;
+
+@Service
 public interface SPIInterface {
   public interface NestedSPIInterface {}
 }

--- a/blackbox-test-spi/src/main/java/module-info.java
+++ b/blackbox-test-spi/src/main/java/module-info.java
@@ -8,7 +8,8 @@ module io.avaje.spi.blackbox {
   provides SPIInterface with
   		io.avaje.spi.test. CommonClass,
 
-  		io.avaje.spi. test.CommonClass2;
+  		io.avaje.spi. test.CommonClass2,
+  		io.avaje.spi. test.CommonClass3;
   exports io.avaje.spi.test;
 
   provides io.avaje.spi.test.SPIInterface.NestedSPIInterface with CommonClass2;


### PR DESCRIPTION
Now we can do 

```java
@Service
sealed interface A permits B {}

non-sealed interface B extends A {}

abstract class C implements B {}

@ServiceProvider
class D extends C, implements J, K {}
```

and correctly infer that `D` should be registered as an `A` provider.

Also, the module error message will display all required modules in the implementation.