### PR TITLE
Correctly handle nested types with Dollar Signs

### DIFF
--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
@@ -25,7 +25,7 @@ final class ModuleReader {
   }
 
   private void add(String k, Set<String> v) {
-    missingServicesMap.put(Utils.getFQNFromBinaryType(k), v.stream().map(Utils::getFQNFromBinaryType).collect(toSet()));
+    missingServicesMap.put(Utils.fqnFromBinaryType(k), v.stream().map(Utils::fqnFromBinaryType).collect(toSet()));
   }
 
   void read(BufferedReader reader, ModuleElement element) throws IOException {
@@ -43,22 +43,18 @@ final class ModuleReader {
       }
     }
 
-    module
-        .provides()
-        .forEach(
-            p -> {
-              if (!missingServicesMap.containsKey(p.service())) {
-                return;
-              }
+    module.provides().forEach(p -> {
+      if (!missingServicesMap.containsKey(p.service())) {
+        return;
+      }
 
-              var impls = p.implementations();
-              var missing = missingServicesMap.get(p.service());
-
-              if (missing.size() != impls.size()) {
-                return;
-              }
-              impls.stream().map(Utils::getFQNFromBinaryType).forEach(missing::remove);
-            });
+      var impls = p.implementations();
+      var missing = missingServicesMap.get(p.service());
+      if (missing.size() != impls.size()) {
+        return;
+      }
+      impls.stream().map(Utils::fqnFromBinaryType).forEach(missing::remove);
+    });
   }
 
   boolean staticWarning() {

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
@@ -197,7 +197,7 @@ public class ServiceProcessor extends AbstractProcessor {
     try (var servicePaths = Files.walk(servicesDirectory, 1).skip(1)) {
       Iterable<Path> pathIterable = servicePaths::iterator;
       for (var servicePath : pathIterable) {
-        final var contract = Utils.getFQNFromBinaryType(servicePath.getFileName().toString());
+        final var contract = Utils.fqnFromBinaryType(servicePath.getFileName().toString());
         if (APContext.typeElement(contract) == null) {
           continue;
         }
@@ -338,8 +338,7 @@ public class ServiceProcessor extends AbstractProcessor {
       try (var reader = getModuleInfoReader()) {
         moduleReader.read(reader, moduleElement);
         if (moduleReader.staticWarning()) {
-          logError(
-              moduleElement, "`requires io.avaje.spi` should be `requires static io.avaje.spi;`");
+          logError(moduleElement, "`requires io.avaje.spi` should be `requires static io.avaje.spi;`");
         }
         if (moduleReader.coreWarning()) {
           logWarn(moduleElement, "io.avaje.spi.core should not be used directly");
@@ -355,20 +354,17 @@ public class ServiceProcessor extends AbstractProcessor {
   }
 
   private void logModuleError(ModuleReader moduleReader) {
-    moduleReader
-        .missing()
-        .forEach(
-            (k, v) -> {
-              if (!v.isEmpty()) {
-                logError(
-                    moduleElement,
-                    "Missing `provides %s with %s;` Please ensure that all META-INF service classes are registered correctly",
-                    k,
-                    services.get(k).stream()
-                        .map(Utils::getFQNFromBinaryType)
+    moduleReader.missing().forEach((k, v) -> {
+      if (!v.isEmpty()) {
+        logError(
+                moduleElement,
+                "Missing `provides %s with %s;` Please ensure that all META-INF service classes are registered correctly",
+                k,
+                services.get(k).stream()
+                        .map(Utils::fqnFromBinaryType)
                         .collect(joining(", ")));
-              }
-            });
+      }
+    });
   }
 
   private static boolean buildPluginAvailable() {

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/Utils.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/Utils.java
@@ -2,18 +2,15 @@ package io.avaje.spi.internal;
 
 import static io.avaje.spi.internal.APContext.typeElement;
 
-public class Utils {
+final class Utils {
 
-  static String getFQNFromBinaryType(String binaryType) {
-
+  static String fqnFromBinaryType(String binaryType) {
     var type = typeElement(binaryType.replace("$", "."));
-
     if (type != null) {
       return type.getQualifiedName().toString();
     }
 
     type = typeElement(replaceDollar(binaryType));
-
     if (type != null) {
       return type.getQualifiedName().toString();
     }
@@ -22,7 +19,7 @@ public class Utils {
   }
 
   // replace '$' with '.' only if there is a lowercase letter in front and uppercase letter behind
-  public static String replaceDollar(String str) {
+  static String replaceDollar(String str) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < str.length(); i++) {
       char currChar = str.charAt(i);

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/Utils.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/Utils.java
@@ -1,0 +1,43 @@
+package io.avaje.spi.internal;
+
+import static io.avaje.spi.internal.APContext.typeElement;
+
+public class Utils {
+
+  static String getFQNFromBinaryType(String binaryType) {
+
+    var type = typeElement(binaryType.replace("$", "."));
+
+    if (type != null) {
+      return type.getQualifiedName().toString();
+    }
+
+    type = typeElement(replaceDollar(binaryType));
+
+    if (type != null) {
+      return type.getQualifiedName().toString();
+    }
+
+    return binaryType;
+  }
+
+  // replace '$' with '.' only if there is a lowercase letter in front and uppercase letter behind
+  public static String replaceDollar(String str) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < str.length(); i++) {
+      char currChar = str.charAt(i);
+      if (currChar == '$' && i > 0 && i < str.length() - 1) {
+        char prevChar = str.charAt(i - 1);
+        char nextChar = str.charAt(i + 1);
+        if (Character.isLowerCase(prevChar) && Character.isUpperCase(nextChar)) {
+          sb.append('.');
+        } else {
+          sb.append(currChar);
+        }
+      } else {
+        sb.append(currChar);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/avaje-spi-core/src/test/java/io/avaje/spi/internal/UtilsTest.java
+++ b/avaje-spi-core/src/test/java/io/avaje/spi/internal/UtilsTest.java
@@ -1,0 +1,19 @@
+package io.avaje.spi.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UtilsTest {
+
+    @Test
+    void replaceDollar() {
+        assertThat(Utils.replaceDollar("a$B")).isEqualTo("a.B");
+    }
+
+    @Test
+    void replaceDollar_when_leftAsIs() {
+        assertThat(Utils.replaceDollar("A$B")).isEqualTo("A$B");
+        assertThat(Utils.replaceDollar("A$b")).isEqualTo("A$b");
+    }
+}

--- a/blackbox-test-spi/io.avaje.spi.test.SPIInterface$NestedSPIInterface
+++ b/blackbox-test-spi/io.avaje.spi.test.SPIInterface$NestedSPIInterface
@@ -1,1 +1,0 @@
-io.avaje.spi.test.CommonClass2

--- a/blackbox-test-spi/src/main/java/io/avaje/spi/test/CommonClass.java
+++ b/blackbox-test-spi/src/main/java/io/avaje/spi/test/CommonClass.java
@@ -8,4 +8,7 @@ public class CommonClass implements SPIInterface {
   public void common() {
     System.out.println("some string idk");
   }
+
+  @ServiceProvider
+  public static class CommonClassNested$SPIInterface implements NestedSPIInterface {}
 }

--- a/blackbox-test-spi/src/main/java/io/avaje/spi/test/SPIInterface.java
+++ b/blackbox-test-spi/src/main/java/io/avaje/spi/test/SPIInterface.java
@@ -1,8 +1,15 @@
 package io.avaje.spi.test;
 
 import io.avaje.spi.Service;
+import io.avaje.spi.ServiceProvider;
 
 @Service
 public interface SPIInterface {
-  public interface NestedSPIInterface {}
+  public interface NestedSPIInterface {
+    @ServiceProvider
+    public class DefaultNested$$SPIInterface implements NestedSPIInterface {}
+  }
+
+  @ServiceProvider
+  public class DefaultSPIInterface implements SPIInterface {}
 }

--- a/blackbox-test-spi/src/main/java/module-info.java
+++ b/blackbox-test-spi/src/main/java/module-info.java
@@ -10,8 +10,11 @@ module io.avaje.spi.blackbox {
 
   		io.avaje.spi. test.CommonClass2,
   		io.avaje.spi. test.CommonClass3
-  		, io . avaje . spi . test . ManualSPI;
+  		, io . avaje . spi . test . ManualSPI,
+  		 io.avaje.spi.test.SPIInterface.DefaultSPIInterface
+       ;
   exports io.avaje.spi.test;
 
-  provides io.avaje.spi.test.SPIInterface.NestedSPIInterface with CommonClass2;
+  provides io.avaje.spi.test.SPIInterface.NestedSPIInterface with io.avaje.spi.test.CommonClass.CommonClassNested$SPIInterface, io.avaje.spi.test.CommonClass2, io.avaje.spi.test.SPIInterface.NestedSPIInterface.DefaultNested$$SPIInterface;
+
  }


### PR DESCRIPTION
The binary type name of a nested class has `$`, which interferes with valid class names containing `$`.