### PR TITLE
Support Alternate Loading of Generated SPIs

### DIFF
--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
@@ -63,6 +63,7 @@ import io.avaje.prism.GenerateUtils;
   "io.avaje.http.api.Controller",
   "io.avaje.recordbuilder.Generated",
   "io.avaje.prism.GenerateAPContext",
+  "io.avaje.validation.spi.Generated",
   "javax.annotation.processing.Generated",
   "javax.annotation.processing.SupportedAnnotationTypes",
   "javax.annotation.processing.SupportedOptions",

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.avaje</groupId>
 		<artifactId>java11-oss</artifactId>
-		<version>4.0</version>
+		<version>4.3</version>
 	</parent>
 	<groupId>io.avaje</groupId>
 	<artifactId>avaje-spi-parent</artifactId>


### PR DESCRIPTION
Noticed a bit of a problem when using the avaje-spi while using a generator that also writes to the same META-INF/services.

Adds functionality to load SPI information from an alternate directory so that service writing is unimpeded