### PR TITLE
Ignore some Avaje SPIs

### DIFF
--- a/avaje-spi-core/pom.xml
+++ b/avaje-spi-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.avaje</groupId>
 		<artifactId>avaje-spi-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>2.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>avaje-spi-core</artifactId>
 	<name>avaje-spi-core</name>

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
@@ -72,7 +72,6 @@ public class ServiceProcessor extends AbstractProcessor {
 
   @Override
   public SourceVersion getSupportedSourceVersion() {
-
     return SourceVersion.latestSupported();
   }
 
@@ -101,17 +100,10 @@ public class ServiceProcessor extends AbstractProcessor {
 
     final var filer = env.getFiler();
     try {
-      final var uri =
-          filer
-              .createResource(
-                  StandardLocation.CLASS_OUTPUT, "", "META-INF/services/spi-service-locator")
-              .toUri();
+      final var uri = filer
+        .createResource(StandardLocation.CLASS_OUTPUT, "", "META-INF/services/spi-service-locator")
+        .toUri();
       this.servicesDirectory = Path.of(uri).getParent();
-      Path.of(
-          URI.create(
-              uri.toString()
-                  .replace(
-                      "META-INF/services/spi-service-locator", "META-INF/generated-services")));
     } catch (IOException e) {
       // not an issue worth failing over
     }
@@ -119,7 +111,6 @@ public class ServiceProcessor extends AbstractProcessor {
 
   @Override
   public boolean process(Set<? extends TypeElement> tes, RoundEnvironment roundEnv) {
-
     final var annotated =
         Optional.ofNullable(typeElement(ServiceProviderPrism.PRISM_TYPE))
             .map(roundEnv::getElementsAnnotatedWith)
@@ -190,12 +181,11 @@ public class ServiceProcessor extends AbstractProcessor {
       }
       logNote("Writing META-INF/services/%s", contract);
       try (final var file =
-              processingEnv
-                  .getFiler()
-                  .createResource(
-                      StandardLocation.CLASS_OUTPUT, "", "META-INF/services/" + contract)
-                  .openOutputStream();
-          final var pw = new PrintWriter(new OutputStreamWriter(file, StandardCharsets.UTF_8)); ) {
+             processingEnv
+               .getFiler()
+               .createResource(StandardLocation.CLASS_OUTPUT, "", "META-INF/services/" + contract)
+               .openOutputStream();
+           final var pw = new PrintWriter(new OutputStreamWriter(file, StandardCharsets.UTF_8));) {
 
         for (final String value : e.getValue()) {
           pw.println(value);
@@ -230,7 +220,7 @@ public class ServiceProcessor extends AbstractProcessor {
 
           String line;
           while ((line = buffer.readLine()) != null) {
-            line.replaceAll("\\s", "").replace(",", "\n").lines().forEach(impls::add);
+            line.replaceAll("\\s", "").replace(',', '\n').lines().forEach(impls::add);
           }
         } catch (final FileNotFoundException | java.nio.file.NoSuchFileException x) {
           // missing and thus not created yet

--- a/avaje-spi-service/pom.xml
+++ b/avaje-spi-service/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.avaje</groupId>
 		<artifactId>avaje-spi-parent</artifactId>
-		<version>1.12-SNAPSHOT</version>
+		<version>2.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>avaje-spi-service</artifactId>
 	<name>avaje-spi</name>

--- a/blackbox-test-spi/pom.xml
+++ b/blackbox-test-spi/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-spi-parent</artifactId>
-    <version>1.12-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>blackbox-test-spi</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<groupId>io.avaje</groupId>
 	<artifactId>avaje-spi-parent</artifactId>
-	<version>1.12-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>avaje-spi-parent</name>
 	<description>Service configuration generator</description>
@@ -20,12 +20,12 @@
 	  <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
 	  <surefire.useModulePath>false</surefire.useModulePath>
 	</properties>
-  
+
 	<modules>
 		<module>avaje-spi-core</module>
 		<module>avaje-spi-service</module>
 	</modules>
-  
+
 	<profiles>
 	  <profile>
 		<id>central</id>
@@ -40,5 +40,5 @@
 		</modules>
 	  </profile>
 	</profiles>
-  
+
 </project>


### PR DESCRIPTION
Ignores inject, validator, and jsonb spi interfaces due to processor conflicts

- ignores the above
- removes the generated sources logic