### PR TITLE
Make Module Validation take effect only when the SPI is in the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build](https://github.com/avaje/avaje-spi-service/actions/workflows/build.yml/badge.svg)](https://github.com/avaje/avaje-spi-service/actions/workflows/build.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/avaje/avaje-spi-service/blob/master/LICENSE)
-[![Maven Central](https://img.shields.io/maven-central/v/io.avaje/avaje-inject.svg?label=Maven%20Central)](https://mvnrepository.com/artifact/io.avaje/avaje-spi-service)
+[![Maven Central](https://img.shields.io/maven-central/v/io.avaje/avaje-spi-service.svg?label=Maven%20Central)](https://mvnrepository.com/artifact/io.avaje/avaje-spi-service)
 [![Discord](https://img.shields.io/discord/1074074312421683250?color=%237289da&label=discord)](https://discord.gg/Qcqf9R27BR)
 # avaje-spi-service
 Uses Annotation processing to automatically add `META-INF/services` entries for classes and validate `module-info.java` files.

--- a/avaje-spi-core/pom.xml
+++ b/avaje-spi-core/pom.xml
@@ -13,7 +13,7 @@
 		<tag>HEAD</tag>
 	</scm>
   <properties>
-    <avaje.prisms.version>1.31</avaje.prisms.version>
+    <avaje.prisms.version>1.32</avaje.prisms.version>
   </properties>
 
   <dependencies>

--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ModuleReader.java
@@ -38,15 +38,15 @@ final class ModuleReader {
       }
     }
     module.provides().forEach(p -> {
+
       final var contract = replace$(p.service());
+
       if (!missingServicesMap.containsKey(contract)) {
         return;
       }
       var impls = p.implementations();
       var missing = missingServicesMap.get(contract);
-      if (missing.size() != impls.size()) {
-        return;
-      }
+
       impls.stream().map(ModuleReader::replace$).forEach(missing::remove);
     });
   }

--- a/blackbox-test-spi/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
+++ b/blackbox-test-spi/src/main/resources/META-INF/services/io.avaje.inject.spi.InjectExtension
@@ -1,0 +1,1 @@
+io.avaje.inject.events.spi.ObserverManagerPlugin


### PR DESCRIPTION
It should go without saying that you can't add a `provides` clause if the class isn't part of the module. 

This can happen when you write a META-INF/services file that contains an entry for a class not in the module.