### PR TITLE
#47 Improve compile error when maven.compiler.release is less than 11

### DIFF
--- a/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
+++ b/avaje-spi-core/src/main/java/io/avaje/spi/internal/ServiceProcessor.java
@@ -389,7 +389,7 @@ public class ServiceProcessor extends AbstractProcessor {
       .map(Object::toString);
   }
 
-  ModuleElement findModule(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+  void findModule(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     if (this.moduleElement == null) {
       moduleElement =
         annotations.stream()
@@ -397,9 +397,12 @@ public class ServiceProcessor extends AbstractProcessor {
           .flatMap(Collection::stream)
           .findAny()
           .map(this::getModuleElement)
-          .orElseThrow();
+          .orElseThrow(() -> {
+            int javaVersion = processingEnv.getSourceVersion().ordinal();
+            String msg = String.format("Java release version is %s, please set maven.compiler.release to 11 or higher", javaVersion);
+            return new IllegalStateException(msg);
+          });
     }
-    return moduleElement;
   }
 
   ModuleElement getModuleElement(Element e) {


### PR DESCRIPTION
I think we still should add this. I can currently still reproduce the original error with the new prism and spi-service. Perhaps an older dependency but I can still get this improved error message. 

Original error:
java.util.NoSuchElementException: No value present ... thrown by ServiceProcessor.findModule (ServiceProcessor.java:397)