### PR TITLE
Add flag to mark as aggregating to gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 *.factorypath
 *.project
 *.processors
+!**/resources/META-INF/gradle/incremental.annotation.processors
 */bin/
 .DS_Store
 

--- a/avaje-spi-service/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/avaje-spi-service/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+io.avaje.spi.internal.ServiceProcessor,aggregating


### PR DESCRIPTION
Allow gradle to pick this up as an ["Aggregating" annotation processor](https://docs.gradle.org/current/userguide/java_plugin.html#aggregating_annotation_processors)

I wasn't sure what to do with the .gitignore so I just whitelisted files that match the pattern, feel free to change